### PR TITLE
Added link to Figma mockups

### DIFF
--- a/docs/Equifood – Figma.url
+++ b/docs/Equifood – Figma.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=https://www.figma.com/file/dq2noVU21gVElLIIirziDg/Equifood?node-id=0%3A1


### PR DESCRIPTION
The link for the figma mockups can be found in the docs folder.